### PR TITLE
Execute workflow only on release created

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,6 @@
 name: Container Build and Push
 
 on:
-  pull_request:
-    branches: [ "main" ] # Execute workflow on pull requests to main branch
   release:
     types:
       - created # Execute workflow when a new release is created
@@ -13,7 +11,7 @@ env:
 
 jobs:
   build:
-    runs-on: do-runner
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
This pull request modifies the workflow file to ensure that the workflow is only executed when a new release is created, instead of being triggered by pull requests to the main branch. This change improves the efficiency of the workflow and reduces unnecessary executions.