### PR TITLE
fix(helm): make chart deployable

### DIFF
--- a/helm/memenow-resource-manager/Chart.yaml
+++ b/helm/memenow-resource-manager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: memenow-resource-manager
-description: A Helm chart for Kubernetes
+description: Helm chart for the memenow-resource-manager service
 
 type: application
 

--- a/helm/memenow-resource-manager/templates/deployment.yaml
+++ b/helm/memenow-resource-manager/templates/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: memenow-resource-manager.fullname
+  name: memenow-resource-manager
   labels:
     app: memenow-resource-manager
 spec:
@@ -34,11 +34,11 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /
+              path: /health
               port: http
           readinessProbe:
             httpGet:
-              path: /
+              path: /health
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/helm/memenow-resource-manager/templates/service.yaml
+++ b/helm/memenow-resource-manager/templates/service.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - port: {{ .Values.service.port }}80
+    - port: {{ .Values.service.port }}
       targetPort: http
       protocol: TCP
       name: http


### PR DESCRIPTION
## Summary
The Helm chart at `helm/memenow-resource-manager/` had four template bugs that prevented a clean install. Each fix is mechanical and contained to the templates and `Chart.yaml`.

## Related
- Not applicable.

## Updates
| Item | From | To | Notes |
| --- | --- | --- | --- |
| `Chart.yaml` description | `A Helm chart for Kubernetes` | `Helm chart for the memenow-resource-manager service` | `helm create` boilerplate |
| `Deployment.metadata.name` | `memenow-resource-manager.fullname` (literal) | `memenow-resource-manager` | Stale `include` placeholder; chart has no `_helpers.tpl` |
| Probe path (liveness + readiness) | `/` | `/health` | Server registers `/ok`, `/health`, `/version`, `/v1/create`; `/` returns 404 |
| Service `spec.ports.port` | `{{ .Values.service.port }}80` | `{{ .Values.service.port }}` | Concat rendered `port: 8080` instead of `port: 80` |

## Details
### Chart.yaml description
- Implementation notes: One-line description replacing the `helm create` default.
- Reviewer focus: Wording only.

### Deployment metadata.name
- Implementation notes: The chart has no `templates/_helpers.tpl` defining a `fullname` template, so `memenow-resource-manager.fullname` was a literal Kubernetes resource name (containing a `.`), not a Helm expression. Replaced with the chart name to match the existing Service name and the `app:` label selector.
- Reviewer focus: Any installation using the previous literal name would be replaced under the new name. Given \`values.yaml\` image tag is a cosign \`.sig\` reference rather than an image tag, the chart appears unused in practice.

### Probe paths
- Implementation notes: Both \`livenessProbe\` and \`readinessProbe\` now hit \`/health\`. The server returns 200 from both \`/ok\` and \`/health\`; \`/health\` is conventional and is documented in \`README.md\`.
- Reviewer focus: Confirm \`/health\` is preferred over \`/ok\`.

### Service spec.ports.port
- Implementation notes: Removed the trailing literal \`80\` after the template expression. With \`service.port: 80\` in \`values.yaml\`, the Service now binds port 80, mapped to the named container port \`http\` (containerPort 8080).
- Reviewer focus: Confirm intent is to expose the Service on 80, not 8080.

## Testing
- \`helm lint helm/memenow-resource-manager/\` -- passed (1 INFO: icon recommended; pre-existing).
- \`helm template test-release helm/memenow-resource-manager/\` -- renders cleanly; Service port 80 -> targetPort http -> containerPort 8080; probes on \`/health\`; Deployment name \`memenow-resource-manager\`.
- Manual deploy: Not run; no cluster available in this environment.

## Screenshots / Notes
- Not applicable.

## Breaking changes
- Deployment resource name changes from the literal \`memenow-resource-manager.fullname\` to \`memenow-resource-manager\`. Existing installs (if any) would be replaced rather than upgraded. The chart looks unused based on the \`values.yaml\` image tag (\`.sig\` cosign reference), but verify before merging if your cluster has it.

## Risks and rollout
- Low risk: chart appears unused. Out-of-band: \`values.yaml\` image tag is a cosign signature reference, not an image -- ImagePull will still fail until the tag is set to a real release tag. Out of scope for this PR.
- Adjacent issue noticed but out of scope: the root \`.gitignore\` line \`memenow-resource-manager\` matches \`helm/memenow-resource-manager/\` and forces \`git add -f\` for new files under that directory. Worth a follow-up to anchor the pattern (e.g. \`/memenow-resource-manager\`).

## Checklist
- [x] Tests added/updated if needed -- N/A; \`helm lint\` is the standard verification.
- [x] Docs updated if needed -- \`Chart.yaml\` description updated; \`/health\` matches \`README.md\`.
- [ ] Backward compatibility considered -- see Breaking changes.
- [x] Rollout/monitoring considerations noted.